### PR TITLE
[Ready for review] Fix Fork & Edit on Github links and add a translator

### DIFF
--- a/content/index.es.md
+++ b/content/index.es.md
@@ -13,7 +13,7 @@ translators:
 
 github:
   repository: w3c/wai-teach-advocate-overview
-  path: "index.es.md"
+  path: "content/index.es.md"
 
 feedbackmail: wai@w3.org
 footer: > # Text in footer in HTML

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -16,7 +16,7 @@ contributors:
 
 github:
   repository: w3c/wai-teach-advocate-overview
-  path: "index.fr.md"
+  path: "content/index.fr.md"
 
 feedbackmail: wai@w3.org
 class: tight-page

--- a/content/index.fr.md
+++ b/content/index.fr.md
@@ -10,9 +10,9 @@ permalink: /teach-advocate/fr
 
 translators:
 - name: "Sofia Ahmed"
+- name: "Rémi Bétin"
 contributors:
 - name: "Sandra Velarde Gonzalez (ETNIC)"
-- name: "Rémi Bétin"
 
 github:
   repository: w3c/wai-teach-advocate-overview

--- a/content/index.md
+++ b/content/index.md
@@ -10,7 +10,7 @@ permalink: /teach-advocate/
 
 github:
   repository: w3c/wai-teach-advocate-overview
-  path: "index.md"
+  path: "content/index.md"
 
 feedbackmail: wai@w3.org
 class: tight-page


### PR DESCRIPTION
Since 18e83964a15396ac1729848fd447f75e689b49f8, "Fork & Edit on Github" links are not working anymore because the files have been move to /content. I intend to fix it in this PR (@shawna-slh @SteveALee : tell me if this is the right way of if you have already identified the issue and had another fix in mind).

I also included my name as translator of the french version, as suggested by @shawna-slh & @soahmed2031